### PR TITLE
Create RadioGroup Component with Types and Visual Testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-checkbox": "^1.1.3",
     "@radix-ui/react-form": "^0.1.1",
     "@radix-ui/react-icons": "^1.3.2",
+    "@radix-ui/react-radio-group": "^1.2.3",
     "@radix-ui/react-scroll-area": "^1.0.0",
     "@radix-ui/react-select": "^2.1.4",
     "@radix-ui/react-slot": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@radix-ui/react-icons':
         specifier: ^1.3.2
         version: 1.3.2(react@19.0.0)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.2.3
+        version: 1.2.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-scroll-area':
         specifier: ^1.0.0
         version: 1.2.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1481,6 +1484,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.2':
+    resolution: {integrity: sha512-9z54IEKRxIa9VityapoEYMuByaG42iSy1ZXlY2KcuLSEtq8x4987/N6m15ppoMffgZX72gER2uHe1D9Y6Unlcw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.1':
     resolution: {integrity: sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==}
     peerDependencies:
@@ -1635,6 +1651,45 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.0.2':
+    resolution: {integrity: sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.2.3':
+    resolution: {integrity: sha512-xtCsqt8Rp09FK50ItqEqTJ7Sxanz8EM8dnkVIhJrc/wkMMomSmXHvYbhv3E7Zx4oXh98aaLt9W679SUYXg4IDA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.2':
+    resolution: {integrity: sha512-zgMQWkNO169GtGqRvYrzb0Zf8NhMHS2DuEB/TiEmVnpr5OqPU3i8lfbxaAmC2J/KYuIQxyoQQ6DxepyXp61/xw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-scroll-area@1.2.2':
     resolution: {integrity: sha512-EFI1N/S3YxZEW/lJ/H1jY3njlvTd8tBmgKEn4GHi51+aMm94i6NmAJstsm5cu3yJwYqYc93gpCPm21FeAbFk6g==}
     peerDependencies:
@@ -1663,6 +1718,15 @@ packages:
 
   '@radix-ui/react-slot@1.1.1':
     resolution: {integrity: sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.1.2':
+    resolution: {integrity: sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -6881,6 +6945,18 @@ snapshots:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
+  '@radix-ui/react-collection@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.0.7)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.7
+      '@types/react-dom': 19.0.3(@types/react@19.0.7)
+
   '@radix-ui/react-compose-refs@1.1.1(@types/react@19.0.7)(react@19.0.0)':
     dependencies:
       react: 19.0.0
@@ -7010,6 +7086,50 @@ snapshots:
       '@types/react': 19.0.7
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
+  '@radix-ui/react-primitive@2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.1.2(@types/react@19.0.7)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.7
+      '@types/react-dom': 19.0.3(@types/react@19.0.7)
+
+  '@radix-ui/react-radio-group@1.2.3(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-roving-focus': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-use-previous': 1.1.0(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@19.0.7)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.7
+      '@types/react-dom': 19.0.3(@types/react@19.0.7)
+
+  '@radix-ui/react-roving-focus@1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-collection': 1.1.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-direction': 1.1.0(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.7)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.7)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.7
+      '@types/react-dom': 19.0.3(@types/react@19.0.7)
+
   '@radix-ui/react-scroll-area@1.2.2(@types/react-dom@19.0.3(@types/react@19.0.7))(@types/react@19.0.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/number': 1.1.0
@@ -7057,6 +7177,13 @@ snapshots:
       '@types/react-dom': 19.0.3(@types/react@19.0.7)
 
   '@radix-ui/react-slot@1.1.1(@types/react@19.0.7)(react@19.0.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.0)
+      react: 19.0.0
+    optionalDependencies:
+      '@types/react': 19.0.7
+
+  '@radix-ui/react-slot@1.1.2(@types/react@19.0.7)(react@19.0.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.7)(react@19.0.0)
       react: 19.0.0

--- a/src/common/components/radioGroup/radioGroup.module.css
+++ b/src/common/components/radioGroup/radioGroup.module.css
@@ -1,0 +1,139 @@
+.radioGroupWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.circle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 100%;
+  background-color: transparent;
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--dark-300);
+  }
+
+  &:active {
+    background-color: var(--dark-100);
+  }
+
+  &:focus-visible {
+    border: none;
+    outline: none;
+    background-color: var(--dark-500);
+  }
+
+  &[aria-disabled="true"] {
+    cursor: default;
+    background-color: transparent;
+  }
+}
+
+.radioBaseStyles {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.Indicator {
+  width: 12px;
+  height: 12px;
+  background-color: var(--light-100);
+  border-radius: 50%;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+
+  &[aria-disabled="true"] {
+    cursor: default;
+    background-color: var(--dark-100);
+  }
+}
+
+.itemWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--light-100);
+  background-color: var(--dark-700);
+  border-radius: 50%;
+  position: relative;
+  cursor: pointer;
+  transition: border-color 0.2s ease-in-out;
+
+  &[data-state="checked"] {
+    border-color: var(--light-100);
+    background-color: transparent;
+  }
+
+  &[data-state="checked"] .Indicator {
+    opacity: 1;
+  }
+
+  &:active {
+    background-color: var(--dark-100);
+  }
+
+  &:hover {
+    background-color: var(--dark-300);
+  }
+
+  &:focus-visible {
+    background-color: var(--dark-500);
+    outline: none;
+  }
+
+  &:disabled {
+    cursor: default;
+    border: 2px solid var(--dark-100);
+
+    &:hover {
+      background-color: transparent;
+    }
+  }
+}
+
+.optionLabel {
+  margin-left: 100px;
+  flex-shrink: 0;
+  cursor: pointer;
+
+  &[aria-disabled="true"] {
+    cursor: default;
+    color: var(--light-900);
+  }
+}
+
+/* label position */
+.label-top {
+  flex-direction: column;
+}
+
+.label-bottom {
+  flex-direction: column-reverse;
+}
+
+.label-left {
+  flex-direction: row;
+  justify-content: flex-start;
+}
+
+.label-right {
+  flex-direction: row;
+  justify-content: flex-end;
+}
+
+.label-center {
+  flex-direction: row;
+  justify-content: center;
+}

--- a/src/common/components/radioGroup/radioGroup.stories.tsx
+++ b/src/common/components/radioGroup/radioGroup.stories.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof RadioGroup>;
 export const RadioGroupOptions: Story = {
   args: {
     label: "radio group label",
-    options: [{ value: "option1", label: "option1" }],
+    options: [{ value: "option1", optionLabel: "option1" }],
     labelPosition: "top",
     disabled: false,
   },
@@ -35,7 +35,7 @@ export const RadioGroupOptions: Story = {
 export const RadioGroupDisabled: Story = {
   args: {
     label: "radio group label",
-    options: [{ value: "option1", label: "option1" }],
+    options: [{ value: "option1", optionLabel: "option1" }],
     labelPosition: "bottom",
     disabled: true,
   },

--- a/src/common/components/radioGroup/radioGroup.stories.tsx
+++ b/src/common/components/radioGroup/radioGroup.stories.tsx
@@ -35,12 +35,8 @@ export const RadioGroupOptions: Story = {
 export const RadioGroupDisabled: Story = {
   args: {
     label: "radio group label",
-    options: [
-      { value: "option1", label: "option1" },
-      { value: "option2", label: "option2" },
-      { value: "option3", label: "option3" },
-      { value: "option4", label: "option4" },
-    ],
+    options: [{ value: "option1", label: "option1" }],
+    labelPosition: "bottom",
     disabled: true,
   },
 };

--- a/src/common/components/radioGroup/radioGroup.stories.tsx
+++ b/src/common/components/radioGroup/radioGroup.stories.tsx
@@ -1,0 +1,46 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { RadioGroup } from "common/components/radioGroup/radioGroup";
+
+const meta: Meta<typeof RadioGroup> = {
+  title: "Components/RadioGroup",
+  component: RadioGroup,
+  tags: ["autodocs"],
+  argTypes: {
+    options: {
+      control: { type: "object" },
+    },
+    labelPosition: {
+      control: { type: "select" },
+      options: ["top", "right", "bottom", "left", "center"],
+    },
+    disabled: { control: "boolean" },
+  },
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof RadioGroup>;
+
+export default meta;
+type Story = StoryObj<typeof RadioGroup>;
+
+export const RadioGroupOptions: Story = {
+  args: {
+    label: "radio group label",
+    options: [{ value: "option1", label: "option1" }],
+    labelPosition: "top",
+    disabled: false,
+  },
+};
+
+export const RadioGroupDisabled: Story = {
+  args: {
+    label: "radio group label",
+    options: [
+      { value: "option1", label: "option1" },
+      { value: "option2", label: "option2" },
+      { value: "option3", label: "option3" },
+      { value: "option4", label: "option4" },
+    ],
+    disabled: true,
+  },
+};

--- a/src/common/components/radioGroup/radioGroup.stories.tsx
+++ b/src/common/components/radioGroup/radioGroup.stories.tsx
@@ -35,12 +35,7 @@ export const RadioGroupOptions: Story = {
 export const RadioGroupDisabled: Story = {
   args: {
     label: "radio group label",
-    options: [
-      { value: "option1", label: "option1" },
-      { value: "option2", label: "option2" },
-      { value: "option3", label: "option3" },
-      { value: "option4", label: "option4" },
-    ],
+    options: [{ value: "option1", label: "option1" }],
     disabled: true,
   },
 };

--- a/src/common/components/radioGroup/radioGroup.tsx
+++ b/src/common/components/radioGroup/radioGroup.tsx
@@ -47,7 +47,7 @@ export const RadioGroup = forwardRef<ComponentRef<typeof RadixRadioGroup.Root>, 
                 <RadixRadioGroup.Indicator className={clsx(s.Indicator)} aria-disabled={disabled} />
                 <Typography variant={"regular_14"} color={"light"} textAlign={"right"} asChild>
                   <label htmlFor={`${id}-${index}`} className={s.optionLabel} aria-disabled={disabled}>
-                    {option.label}
+                    {option.optionLabel}
                   </label>
                 </Typography>
               </RadixRadioGroup.Item>

--- a/src/common/components/radioGroup/radioGroup.tsx
+++ b/src/common/components/radioGroup/radioGroup.tsx
@@ -1,0 +1,76 @@
+import * as RadixRadioGroup from "@radix-ui/react-radio-group";
+import s from "./radioGroup.module.css";
+import { ComponentPropsWithoutRef, ComponentRef, forwardRef, useId } from "react";
+import { PositionProps } from "common/types";
+import { clsx } from "clsx";
+import { Typography } from "common/components/typography/typography";
+import { RadioOptionProps } from "common/types/RadioOptionProps/RadioOptionProps";
+
+export const RadioGroup = forwardRef<ComponentRef<typeof RadixRadioGroup.Root>, Props>(
+  (
+    {
+      className,
+      labelClassName,
+      label,
+      labelPosition,
+      defaultValue,
+      value,
+      onValueChange,
+      options,
+      disabled = false,
+      ...rest
+    },
+    ref
+  ) => {
+    const generateId = useId();
+    const id = rest.id || generateId;
+
+    return (
+      <div className={clsx(s.radioGroupWrapper, labelPosition && s[`label-${labelPosition}`], className)}>
+        <RadixRadioGroup.Root
+          key={id}
+          className={s.radioBaseStyles}
+          defaultValue={defaultValue}
+          value={value}
+          onValueChange={onValueChange}
+          ref={ref}
+          {...rest}
+        >
+          {options.map((option, index) => (
+            <div key={`${id}-${index}`} className={s.circle} aria-disabled={disabled}>
+              <RadixRadioGroup.Item
+                key={`${id}-${index}`}
+                className={s.itemWrapper}
+                value={option.value}
+                disabled={disabled}
+              >
+                <RadixRadioGroup.Indicator className={clsx(s.Indicator)} aria-disabled={disabled} />
+                <Typography variant={"regular_14"} color={"light"} textAlign={"right"} asChild>
+                  <label htmlFor={`${id}-${index}`} className={s.optionLabel} aria-disabled={disabled}>
+                    {option.label}
+                  </label>
+                </Typography>
+              </RadixRadioGroup.Item>
+            </div>
+          ))}
+        </RadixRadioGroup.Root>
+        {label && (
+          <Typography variant={"regular_14"} color={"light"} asChild>
+            <label htmlFor={id} className={labelClassName} aria-disabled={disabled}>
+              {label}
+            </label>
+          </Typography>
+        )}
+      </div>
+    );
+  }
+);
+
+type Props = {
+  labelClassName?: string;
+  label?: string;
+  labelPosition?: PositionProps;
+  options: RadioOptionProps[];
+} & ComponentPropsWithoutRef<typeof RadixRadioGroup.Root>;
+
+RadioGroup.displayName = "RadioGroup";

--- a/src/common/components/radioGroup/radioGroup.tsx
+++ b/src/common/components/radioGroup/radioGroup.tsx
@@ -1,7 +1,7 @@
 import * as RadixRadioGroup from "@radix-ui/react-radio-group";
 import s from "./radioGroup.module.css";
 import { ComponentPropsWithoutRef, ComponentRef, forwardRef, useId } from "react";
-import { PositionProps } from "common/types";
+import { NullableProps, PositionProps } from "common/types";
 import { clsx } from "clsx";
 import { Typography } from "common/components/typography/typography";
 import { RadioOptionProps } from "common/types/RadioOptionProps/RadioOptionProps";
@@ -12,7 +12,7 @@ export const RadioGroup = forwardRef<ComponentRef<typeof RadixRadioGroup.Root>, 
       className,
       labelClassName,
       label,
-      labelPosition,
+      labelPosition = "bottom",
       defaultValue,
       value,
       onValueChange,
@@ -26,7 +26,7 @@ export const RadioGroup = forwardRef<ComponentRef<typeof RadixRadioGroup.Root>, 
     const id = rest.id || generateId;
 
     return (
-      <div className={clsx(s.radioGroupWrapper, labelPosition && s[`label-${labelPosition}`], className)}>
+      <div className={clsx(s.radioGroupWrapper, s[`label-${labelPosition}`], className)}>
         <RadixRadioGroup.Root
           key={id}
           className={s.radioBaseStyles}
@@ -68,7 +68,7 @@ export const RadioGroup = forwardRef<ComponentRef<typeof RadixRadioGroup.Root>, 
 
 type Props = {
   labelClassName?: string;
-  label?: string;
+  label?: NullableProps<string>;
   labelPosition?: PositionProps;
   options: RadioOptionProps[];
 } & ComponentPropsWithoutRef<typeof RadixRadioGroup.Root>;

--- a/src/common/types/RadioOptionProps/RadioOptionProps.ts
+++ b/src/common/types/RadioOptionProps/RadioOptionProps.ts
@@ -1,0 +1,6 @@
+import { NullableProps } from "../NullableProps/NullableProps";
+
+export type RadioOptionProps = {
+  value: string;
+  label?: NullableProps<string>;
+};

--- a/src/common/types/RadioOptionProps/RadioOptionProps.ts
+++ b/src/common/types/RadioOptionProps/RadioOptionProps.ts
@@ -2,5 +2,5 @@ import { NullableProps } from "../NullableProps/NullableProps";
 
 export type RadioOptionProps = {
   value: string;
-  label?: NullableProps<string>;
+  optionLabel?: NullableProps<string>;
 };


### PR DESCRIPTION
### Description

This pull request introduces the `RadioGroup` component, including the following changes:

- Installed the Radix `RadioGroup` component library.
- Created a common type for `RadioGroup` options to ensure type safety.
- Designed and implemented styles for the `RadioGroup` layout.
- Added a corresponding Storybook story for visual testing and interaction validation.