### PR TITLE
Refactor Select component and add common story args

### DIFF
--- a/src/common/components/header/header.tsx
+++ b/src/common/components/header/header.tsx
@@ -24,7 +24,7 @@ export const Header: FC<Props> = ({ isAuth }) => {
           Inctagram
         </Typography>
         <div className={s.selectButtonsWrapper}>
-          <Select defaultValue={"en"} items={selectLanguages} />
+          <Select defaultValue={"en"} items={selectLanguages} groupLabel={"Languages"} />
           <div className={s.buttonsWrapper}>
             {isAuth ? (
               <Button variant={"primary"}>Log out</Button>

--- a/src/common/components/select/select.module.css
+++ b/src/common/components/select/select.module.css
@@ -20,6 +20,7 @@
   padding: 0 15px;
   gap: 5px;
   background-color: var(--dark-500);
+  border-radius: 2px;
   border: 1px solid var(--dark-100);
   outline: 1px solid transparent;
   cursor: pointer;
@@ -61,12 +62,13 @@
   justify-content: center;
   width: var(--radix-select-trigger-width);
   background-color: var(--dark-500);
+  border-radius: 2px;
   border: 1px solid var(--dark-100);
   color: var(--light-100);
   cursor: pointer;
   margin-top: 20px;
   position: absolute;
-  top: -15px;
+  top: -20px;
   z-index: 101;
 }
 

--- a/src/common/components/select/select.stories.tsx
+++ b/src/common/components/select/select.stories.tsx
@@ -11,6 +11,10 @@ const meta: Meta<typeof Select> = {
     },
     disabled: { control: "boolean" },
   },
+  args: {
+    defaultValue: "english",
+    groupLabel: "Languages",
+  },
   parameters: {
     layout: "centered",
   },

--- a/src/common/components/select/select.tsx
+++ b/src/common/components/select/select.tsx
@@ -5,10 +5,25 @@ import * as RadixSelect from "@radix-ui/react-select";
 import { clsx } from "clsx";
 import { SelectItem } from "common/components/select/selectItems/selectItems";
 import { Typography } from "common/components/typography/typography";
-import { SelectItemsProps } from "common/types";
+import { NullableProps, SelectItemsProps } from "common/types";
 
 export const Select = forwardRef<ComponentRef<typeof RadixSelect.Trigger>, Props>(
-  ({ className, labelClassName, defaultValue, label, disabled, items, ...rest }, ref) => {
+  (
+    {
+      className,
+      labelClassName,
+      placeholder,
+      defaultValue,
+      value,
+      label,
+      disabled,
+      items,
+      groupLabel,
+      withSeparator = true,
+      ...rest
+    },
+    ref
+  ) => {
     const generatedId = useId();
     const id = rest.id || generatedId;
 
@@ -22,9 +37,14 @@ export const Select = forwardRef<ComponentRef<typeof RadixSelect.Trigger>, Props
           </Typography>
         )}
         <Typography variant={"regular_14"} color={"light"}>
-          <RadixSelect.Root defaultValue={defaultValue} disabled={disabled}>
+          <RadixSelect.Root
+            defaultValue={defaultValue}
+            value={value}
+            onValueChange={rest.onValueChange}
+            disabled={disabled}
+          >
             <RadixSelect.Trigger id={id} className={clsx(s.trigger, className)} ref={ref} {...rest}>
-              <RadixSelect.Value placeholder="Select language" />
+              <RadixSelect.Value placeholder={placeholder} />
               <RadixSelect.Icon>
                 <ChevronDownIcon className={s.iconDown} />
               </RadixSelect.Icon>
@@ -37,12 +57,16 @@ export const Select = forwardRef<ComponentRef<typeof RadixSelect.Trigger>, Props
                 </RadixSelect.ScrollUpButton>
                 <RadixSelect.Viewport className={s.Viewport}>
                   <RadixSelect.Group>
-                    <RadixSelect.Label style={{ marginLeft: 5 }}>Languages</RadixSelect.Label>
-                    <RadixSelect.Separator className={s.Separator} />
+                    {groupLabel && (
+                      <>
+                        <RadixSelect.Label style={{ marginLeft: 5 }}>{groupLabel}</RadixSelect.Label>
+                        {withSeparator && <RadixSelect.Separator className={s.Separator} />}
+                      </>
+                    )}
                     {items.map((item) => (
                       <SelectItem key={item.value} value={item.value}>
                         <Typography variant={"regular_14"} className={s.selectItems}>
-                          {item.icon} {item.label}
+                          {item.icon && item.icon} {item.label}
                         </Typography>
                       </SelectItem>
                     ))}
@@ -64,7 +88,10 @@ type Props = {
   id?: string;
   className?: string;
   labelClassName?: string;
+  placeholder?: string;
   label?: string;
+  groupLabel?: NullableProps<string>;
+  withSeparator?: boolean;
   items: SelectItemsProps[];
 } & ComponentPropsWithoutRef<typeof RadixSelect.Root>;
 


### PR DESCRIPTION
### Description

This pull request includes the following updates:
- Introduced new props (`placeholder`, `groupLabel`, `withSeparator`) for the `Select` component.
- Refactored the `Select` component to utilize the newly added props.
- Updated all storybook stories of the `Select` component with consistent `defaultValue` and `groupLabel` in their arguments.
